### PR TITLE
Trak 24 tracks sort by multiple columns

### DIFF
--- a/graphql/src/main/java/com/dovendev/track/graphql/GraphQLProvider.java
+++ b/graphql/src/main/java/com/dovendev/track/graphql/GraphQLProvider.java
@@ -60,10 +60,7 @@ public class GraphQLProvider {
         .scalar(ExtendedScalars.DateTime)
         .type(newTypeWiring("Query")
             .dataFetcher("getTrack", trackDataFetchers.getTrackDataFetcher())
-            .dataFetcher("findAll", trackDataFetchers.findAllTrackDataFetcher())
-            .dataFetcher("getAllPageable", trackDataFetchers.getAllPageable())
-            .dataFetcher("findByTitleDescription",
-                trackDataFetchers.findByTitleDescriptionDataFetcher())
+            .dataFetcher("getTracks", trackDataFetchers.getTracksDataFetcher())
             .dataFetcher("getActivities", activityDataFetcher.getActivities())
             .dataFetcher("getActivity", activityDataFetcher.getActivity())
         )

--- a/graphql/src/main/resources/schema.graphql
+++ b/graphql/src/main/resources/schema.graphql
@@ -3,9 +3,7 @@ scalar Duration
 
 type Query {
     getTrack(id: ID!): Track
-    findAll: [Track!]!
-    getAllPageable(limit: Int!, after: ID): TrackConnection
-    findByTitleDescription(searchText: String!): [Track!]!
+    getTracks(limit: Int!, after: ID, sort: [TrackSort!], searchText: String): TrackConnection
 
     getLink(id: ID!): Link
 
@@ -76,8 +74,25 @@ type TrackEdge {
 }
 
 type PageInfo {
-  startCursor: ID
-  endCursor: ID
-  hasPreviousPage: Boolean!
-  hasNextPage: Boolean!
+    startCursor: ID
+    endCursor: ID
+    hasPreviousPage: Boolean!
+    hasNextPage: Boolean!
+}
+
+enum TrackSort {
+    ID_ASC
+    ID_DESC
+    UPLOAD_TIME_ASC
+    UPLOAD_TIME_DESC
+    TITLE_ASC
+    TITLE_DESC
+    TIME_ASC
+    TIME_DESC
+    LENGTH_ASC
+    LENGTH_DESC
+    ALT_DIFF_ASC
+    ALT_DIFF_DESC
+    ACTIVITY_NAME_ASC
+    ACTIVITY_NAME_DESC
 }

--- a/persistence/src/main/java/com/dovendev/track/jpa/entities/Track.java
+++ b/persistence/src/main/java/com/dovendev/track/jpa/entities/Track.java
@@ -18,6 +18,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import org.springframework.data.util.ReflectionUtils;
 
@@ -37,7 +38,9 @@ public class Track {
 
   private OffsetDateTime uploadTime;
 
-  @OneToOne private Activity activity;
+  @OneToOne
+  @OrderBy("name")
+  private Activity activity;
 
   @OneToMany(cascade = CascadeType.ALL)
   @JoinColumn(name = "trackId", referencedColumnName = "id")

--- a/persistence/src/main/java/com/dovendev/track/jpa/entities/TrackSort.java
+++ b/persistence/src/main/java/com/dovendev/track/jpa/entities/TrackSort.java
@@ -10,8 +10,15 @@ public enum TrackSort {
   UPLOAD_TIME_ASC(new Order(Direction.ASC, "uploadTime")),
   UPLOAD_TIME_DESC(new Order(Direction.DESC, "uploadTime")),
   TITLE_ASC(new Order(Direction.ASC, "title")),
-  TITLE_DESC(new Order(Direction.DESC, "title"));
-
+  TITLE_DESC(new Order(Direction.DESC, "title")),
+  TIME_ASC(new Order(Direction.ASC, "time")),
+  TIME_DESC(new Order(Direction.DESC, "time")),
+  LENGTH_ASC(new Order(Direction.ASC, "length")),
+  LENGTH_DESC(new Order(Direction.DESC, "length")),
+  ALT_DIFF_ASC(new Order(Direction.ASC, "altitudeDifference")),
+  ALT_DIFF_DESC(new Order(Direction.DESC, "altitudeDifference")),
+  ACTIVITY_NAME_ASC(new Order(Direction.ASC, "activity")),
+  ACTIVITY_NAME_DESC(new Order(Direction.DESC,"activity"));
 
   private final Sort.Order sortOrder;
 

--- a/persistence/src/main/java/com/dovendev/track/jpa/repositories/TrackRepository.java
+++ b/persistence/src/main/java/com/dovendev/track/jpa/repositories/TrackRepository.java
@@ -15,10 +15,6 @@ import org.springframework.data.repository.query.Param;
 public interface TrackRepository extends CustomRepository<Track, Long>,
     QuerydslPredicateExecutor<Track>, QuerydslBinderCustomizer<QTrack> {
 
-  @Query("SELECT DISTINCT t FROM Track t WHERE UPPER(t.title) LIKE CONCAT('%',UPPER(:searchText),'%') "
-      + "OR UPPER(t.description) LIKE CONCAT('%',UPPER(:searchText),'%') ORDER BY t.uploadTime DESC")
-  List<Track> findByTitleDescription(@Param("searchText") String searchText);
-
   @Override
   default void customize(QuerydslBindings bindings, QTrack root) {
     bindings.bind(String.class)

--- a/persistence/src/main/java/com/dovendev/track/jpa/services/TrackService.java
+++ b/persistence/src/main/java/com/dovendev/track/jpa/services/TrackService.java
@@ -1,6 +1,5 @@
 package com.dovendev.track.jpa.services;
 
-import com.dovendev.track.jpa.entities.Activity;
 import com.dovendev.track.jpa.entities.QTrack;
 import com.dovendev.track.jpa.entities.SearchOperation;
 import com.dovendev.track.jpa.entities.Track;
@@ -8,14 +7,13 @@ import com.dovendev.track.jpa.entities.TrackSort;
 import com.dovendev.track.jpa.predicates.TrackPredicatesBuilder;
 import com.dovendev.track.jpa.repositories.TrackRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import java.util.ArrayList;
+import com.querydsl.core.types.dsl.Expressions;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -42,46 +40,46 @@ public class TrackService {
     return track;
   }
 
-  public List<Track> findAll() {
-    return trackRepository.findAll(Sort.by(Direction.DESC, "uploadTime"));
-  }
-
-  public List<Track> findByTitleDescription(String searchText) {
-    return trackRepository.findByTitleDescription(searchText);
-  }
-
-  public List<Track> findAll(int limit, Long cursor, List<TrackSort> sorts) {
+  public List<Track> findAll(int limit, Long cursor, List<TrackSort> sorts, String searchText) {
     List<Sort.Order> sortOrders =
         sorts.stream().map(TrackSort::getSortOrder).collect(Collectors.toList());
     // as final sort, if every other comparator is equal, order by id asc
     // so that we can exclude current cursor, which otherwise will be returned as 1st result
     sortOrders.add(TrackSort.ID_ASC.getSortOrder());
     Pageable pageable = PageRequest.of(0, limit, Sort.by(sortOrders));
-    if (cursor == null) {
-      return trackRepository.findAll(pageable).toList();
-    }
-    final Track edge = findById(cursor);
-    if (edge != null) {
-      final TrackPredicatesBuilder builder = new TrackPredicatesBuilder();
 
-      sorts.forEach(
-          sort -> {
-            final String field = sort.getSortOrder().getProperty();
-            try {
-              final SearchOperation searchOperation =
-                  SearchOperation.getOperationFromSort(sort.getSortOrder().getDirection());
-              builder.with(field, searchOperation, edge.getFieldValue(field));
-            } catch (IllegalAccessException e) {
-              System.err.println("Field not accessible: " + field);
-            }
-          });
+    final TrackPredicatesBuilder builder = new TrackPredicatesBuilder();
+    BooleanExpression predicates = Expressions.asBoolean(true).isTrue();
 
-      BooleanExpression predicates = builder.build();
-      // exclude the edge from the results
-      predicates = predicates.and(QTrack.track.id.ne(cursor));
-      Page<Track> page = trackRepository.findAll(predicates, pageable);
-      return page.toList();
+    if (cursor != null) {
+      final Track edge = findById(cursor);
+
+      if (edge != null) {
+        sorts.forEach(
+            sort -> {
+              final String field = sort.getSortOrder().getProperty();
+              try {
+                final SearchOperation searchOperation =
+                    SearchOperation.getOperationFromSort(sort.getSortOrder().getDirection());
+                builder.with(field, searchOperation, edge.getFieldValue(field));
+              } catch (IllegalAccessException e) {
+                System.err.println("Field not accessible: " + field);
+              }
+            });
+
+        // exclude the edge from the results
+        predicates = builder.build();
+        predicates = predicates.and(QTrack.track.id.ne(cursor));
+      }
     }
-    return new ArrayList<>();
+
+    if (searchText != null && !searchText.isBlank()) {
+      BooleanExpression searchTextPredicate = QTrack.track.title.containsIgnoreCase(searchText)
+          .or(QTrack.track.description.containsIgnoreCase(searchText));
+      predicates = predicates.and(searchTextPredicate);
+    }
+
+    Page<Track> page = trackRepository.findAll(predicates, pageable);
+    return page.toList();
   }
 }


### PR DESCRIPTION
- Add Enum to graphQL schema to list possible tracks' sort types
- Add values to existing TrackSort enum class to get all possible  tracks' sort types
- Unified methods to retrieve tracks to one which paginates, sorts, filters by title and description according to the parameters passed.